### PR TITLE
updating image location and adding longer token TTL

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,19 @@
 version: "3"
 services:
  vampi-secure:
-  image: vampi_docker:latest
+  image: fxlabs/vampi_docker:latest
   container_name: vampi-secure
   ports:
    - 5001:5000
   environment:
    - vulnerable=0
+   - tokentimetolive=300
 
  vampi-vulnerable:
-  image: vampi_docker:latest
+  image: fxlabs/vampi_docker:latest
   container_name: vampi-vulnerable
   ports:
    - 5002:5000
   environment:
    - vulnerable=1
+   - tokentimetolive=300


### PR DESCRIPTION
Just pulled down new changes and tried to test...looks like image location was updated, so fixed that in the docker-compose.yaml file. Also added the setting to allow the token to live for 5 minutes (up from the default 1 minute, which can get a little tiring to fetch a new one).