### PR TITLE
Patch to add Kubernetes deployment files and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,18 @@ Assuming you've built the container per the above steps, run one instance secure
 docker compose up -d
 ~~~~
 
+#### Run it in Kubernetes
+
+Assuming you have access to a Kubernetes cluster and kubectl connected to it:
+
+```
+kubectl apply -f vampi-secure-deployment.yaml,vampi-secure-service.yaml,vampi-vulnerable-deployment.yaml,vampi-vulnerable-service.yaml
+```
+
+ will deploy it and LoadBalancers for you.
+
 ## Customizing token timeout and vulnerable environment or not
+
 If you would like to alter the timeout of the token created after login or if you want to change the environment **not** to be vulnerable then you can use a few ways depending how you run the application.
 
  - If you run it like normal with `python3 app.py` then all you have to do is edit the `alive` and `vuln` variables defined in the `app.py` itself. The `alive` variable is measured in seconds, so if you put `100`, then the token expires after 100 seconds. The `vuln` variable is like boolean, if you set it to `1` then the application is vulnerable, and if you set it to `0` the application is not vulnerable.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Assuming you have access to a Kubernetes cluster and kubectl connected to it:
 kubectl apply -f vampi-secure-deployment.yaml,vampi-secure-service.yaml,vampi-vulnerable-deployment.yaml,vampi-vulnerable-service.yaml
 ```
 
- will deploy it and LoadBalancers for you.
+ will deploy two instances and two LoadBalancers for you.
 
 ## Customizing token timeout and vulnerable environment or not
 

--- a/vampi-secure-deployment.yaml
+++ b/vampi-secure-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.26.1 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: vampi-secure
+  name: vampi-secure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: vampi-secure
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.26.1 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: vampi-secure
+    spec:
+      containers:
+        - env:
+            - name: vulnerable
+              value: "0"
+          image: saltaaron/vampi:latest
+          name: vampi-secure
+          ports:
+            - containerPort: 5000
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/vampi-secure-service.yaml
+++ b/vampi-secure-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.26.1 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: vampi-secure
+  name: vampi-secure
+spec:
+  ports:
+    - name: "5001"
+      port: 5001
+      targetPort: 5000
+  type: LoadBalancer
+  selector:
+    io.kompose.service: vampi-secure

--- a/vampi-vulnerable-deployment.yaml
+++ b/vampi-vulnerable-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.26.1 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: vampi-vulnerable
+  name: vampi-vulnerable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: vampi-vulnerable
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.26.1 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: vampi-vulnerable
+    spec:
+      containers:
+        - env:
+            - name: vulnerable
+              value: "1"
+          image: saltaaron/vampi:latest
+          name: vampi-vulnerable
+          ports:
+            - containerPort: 5000
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/vampi-vulnerable-service.yaml
+++ b/vampi-vulnerable-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.26.1 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: vampi-vulnerable
+  name: vampi-vulnerable
+spec:
+  ports:
+    - name: "5002"
+      port: 5002
+      targetPort: 5000
+  type: LoadBalancer
+  selector:
+    io.kompose.service: vampi-vulnerable
+status:
+  loadBalancer: {}


### PR DESCRIPTION
it does differ from previous ways b/c it's pulling a pre-built image from Docker Hub, but some folks might find this useful.