### PR TITLE
using a builder to shrink final image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+README.md
+docker-compose.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM python:3.7-alpine
-
-RUN mkdir /vampi
+FROM python:3.7-alpine as builder
 RUN apk --update add bash nano g++
-
-ENV vulnerable=1
-ENV tokentimetolive=60
-
 COPY . /vampi
 WORKDIR /vampi
-
 RUN pip install -r requirements.txt
+
+# Build a fresh container, copying across files & compiled parts
+FROM python:3.7-alpine
+COPY . /vampi
+WORKDIR /vampi
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/bin /usr/local/bin
+ENV vulnerable=1
+ENV tokentimetolive=60
 
 ENTRYPOINT ["python"]
 CMD ["app.py"]


### PR DESCRIPTION
Using a builder and copying over compiled files shrinks final image from 367 MB down to 108 MB. Also added a .dockerignore to not bring in non-required files. Have a look at your convenience @erev0s 