### PR TITLE
Corrected OAS spec for _debug

### DIFF
--- a/openapi_specs/openapi3.yml
+++ b/openapi_specs/openapi3.yml
@@ -89,22 +89,25 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    admin:
-                      type: boolean
-                      example: false
-                    email:
-                      type: string
-                      example: 'mail1@mail.com'
-                    password:
-                      type: string
-                      example: 'pass1'
-                    username:
-                      type: string
-                      example: 'name1'
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        admin:
+                          type: boolean
+                          example: false
+                        email:
+                          type: string
+                          example: 'mail1@mail.com'
+                        password:
+                          type: string
+                          example: 'pass1'
+                        username:
+                          type: string
+                          example: 'name1'
   /users/v1/register:
     post:
       tags:


### PR DESCRIPTION
* Original OAS spec indicates an array is returned directly by _debug. The endpoint actually returns an object, with the key `users`, which is itself an array of the users. Spec does not match the return.