### PR TITLE
Add /me endpoint 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-alpine as builder
 RUN apk --update add bash nano g++
-COPY . /vampi
+COPY ./requirements.txt /vampi/requirements.txt
 WORKDIR /vampi
 RUN pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A quick rundown of the actions included can be seen in the following table:
 |:----------:|:-----------------------------:|:--------------------------------------------------:|
 |     GET    |           /createdb           | Creates and populates the database with dummy data |
 |     GET    |               /               |                     VAmPI home                     |
+|     GET    |               /me             |           Displays the user that is logged in       |
 |     GET    |           /users/v1           |      Displays all users with basic information     |
 |     GET    |        /users/v1/_debug       |         Displays all details for all users         |
 |    POST    |       /users/v1/register      |                  Register new user                 |

--- a/api_views/users.py
+++ b/api_views/users.py
@@ -25,6 +25,22 @@ def debug():
     return_value = jsonify({'users': User.get_all_users_debug()})
     return return_value
 
+def me():
+    resp = token_validator(request.headers.get('Authorization'))
+    if "error" in resp:
+        return Response(error_message_helper(resp), 401, mimetype="application/json")
+    else:
+        user = User.query.filter_by(username=resp['sub']).first()
+        responseObject = {
+            'status': 'success',
+            'data': {
+                'username': user.username,
+                'email': user.email,
+                'admin': user.admin
+            }
+        }
+        return Response(json.dumps(responseObject), 200, mimetype="application/json")
+        
 
 def get_by_username(username):
     if User.get_user(username):

--- a/openapi_specs/VAmPI.postman_collection.json
+++ b/openapi_specs/VAmPI.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "07b56784-02d4-47a0-9bcd-03b5bc52f8dd",
+		"_postman_id": "2b4774dd-b3fb-4a63-81f4-353643bbb641",
 		"name": "VAmPI",
 		"description": "OpenAPI v3 specs for VAmPI",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "10538030"
 	},
 	"item": [
 		{
@@ -151,72 +152,10 @@
 							]
 						}
 					},
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
-					"body": null
-				}
-			]
-		},
-		{
-			"name": "Retrieves currently logged in user",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"value": "application/json"
-					}
-				],
-				"url": {
-					"raw": "{{baseUrl}}/me",
-					"host": [
-						"{{baseUrl}}"
-					],
-					"path": [
-						"me"
-					]
-				},
-				"description": "Displays user by username"
-			},
-			"response": [
-				{
-					"name": "Retrieves currently logged in user",
-					"originalRequest": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Accept",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{baseUrl}}/me",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"me"
-							]
-						}
-					},
-					"_postman_previewlanguage": null,
-					"header": null,
-					"cookie": [],
-					"body": null
+					"body": ""
 				}
 			]
 		},
@@ -421,8 +360,8 @@
 							]
 						}
 					},
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
 					"body": "{\n    \"message\": \"Successfully registered. Login to receive an auth token.\",\n    \"status\": \"success\"\n}"
 				}
@@ -521,8 +460,8 @@
 					},
 					"status": "OK",
 					"code": 200,
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
 					"body": "{\n    \"status\": \"fail\",\n    \"message\": \"Password is not correct for the given username.\"\n}"
 				},
@@ -563,12 +502,59 @@
 					},
 					"status": "OK",
 					"code": 200,
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
 					"body": "{\n    \"status\": \"fail\",\n    \"message\": \"Username does not exist\"\n}"
 				}
 			]
+		},
+		{
+			"name": "Retrieves currently logged in user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{auth_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/me",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"me"
+					]
+				},
+				"description": "Displays user by username"
+			},
+			"response": []
 		},
 		{
 			"name": "Add new book",
@@ -806,10 +792,10 @@
 							]
 						}
 					},
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
-					"body": null
+					"body": ""
 				}
 			]
 		},
@@ -924,10 +910,10 @@
 							]
 						}
 					},
-					"_postman_previewlanguage": null,
-					"header": null,
+					"_postman_previewlanguage": "Text",
+					"header": [],
 					"cookie": [],
-					"body": null
+					"body": ""
 				}
 			]
 		},

--- a/openapi_specs/VAmPI.postman_collection.json
+++ b/openapi_specs/VAmPI.postman_collection.json
@@ -256,7 +256,7 @@
 				"description": "Displays all users with basic information"
 			},
 			"response": []
-		}
+		},
 		{
 			"name": "Retrieves all details for all users (debug)",
 			"event": [

--- a/openapi_specs/VAmPI.postman_collection.json
+++ b/openapi_specs/VAmPI.postman_collection.json
@@ -159,6 +159,68 @@
 			]
 		},
 		{
+			"name": "Retrieves currently logged in user",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"url": {
+					"raw": "{{baseUrl}}/me",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"me"
+					]
+				},
+				"description": "Displays user by username"
+			},
+			"response": [
+				{
+					"name": "Retrieves currently logged in user",
+					"originalRequest": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/me",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"me"
+							]
+						}
+					},
+					"_postman_previewlanguage": null,
+					"header": null,
+					"cookie": [],
+					"body": null
+				}
+			]
+		},
+		{
 			"name": "Retrieves all users",
 			"event": [
 				{
@@ -194,7 +256,7 @@
 				"description": "Displays all users with basic information"
 			},
 			"response": []
-		},
+		}
 		{
 			"name": "Retrieves all details for all users (debug)",
 			"event": [

--- a/openapi_specs/openapi3.yml
+++ b/openapi_specs/openapi3.yml
@@ -214,29 +214,38 @@ paths:
                     example: 'Password is not correct for the given username.'
   /me:
     get:
+        security:
+          - bearerAuth: []
         tags:
           - users
         summary: Retrieves currently logged in user
         description: Displays information about the currently authenticated user
         operationId: api_views.users.me
-        security:
-          - bearerAuth: []  # Assuming bearer token authentication is used
         responses:
           '200':
-            description: Successfully display user info
+            description: Display current user info
             content:
               application/json:
                 schema:
                   type: object
                   properties:
-                    username:
+                    data:
+                      type: object
+                      properties:
+                        admin:
+                          type: boolean
+                          example: false
+                        email:
+                          type: string
+                          example: 'mail1@mail.com'
+                        username:
+                          type: string
+                          example: 'name1'
+                    status:
                       type: string
-                      example: 'current_user'
-                    email:
-                      type: string
-                      example: 'current_user@mail.com'
+                      example: 'success'
           '401':
-            description: Invalid or missing authorization header
+            description: Unauthorized access due to expired, invalid, or missing token
             content:
               application/json:
                 schema:
@@ -244,11 +253,12 @@ paths:
                   properties:
                     status:
                       type: string
-                      enum: ['fail']
                       example: 'fail'
                     message:
                       type: string
-                      example: 'Unauthorized access, please provide valid credentials'
+                      enum:
+                        - 'Signature expired. Please log in again.'
+                        - 'Invalid token. Please log in again.'
 
   /users/v1/{username}:
     get:

--- a/openapi_specs/openapi3.yml
+++ b/openapi_specs/openapi3.yml
@@ -212,6 +212,44 @@ paths:
                   message:
                     type: string
                     example: 'Password is not correct for the given username.'
+  /me:
+    get:
+        tags:
+          - users
+        summary: Retrieves currently logged in user
+        description: Displays information about the currently authenticated user
+        operationId: api_views.users.me
+        security:
+          - bearerAuth: []  # Assuming bearer token authentication is used
+        responses:
+          '200':
+            description: Successfully display user info
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    username:
+                      type: string
+                      example: 'current_user'
+                    email:
+                      type: string
+                      example: 'current_user@mail.com'
+          '401':
+            description: Invalid or missing authorization header
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      enum: ['fail']
+                      example: 'fail'
+                    message:
+                      type: string
+                      example: 'Unauthorized access, please provide valid credentials'
+
   /users/v1/{username}:
     get:
       tags:


### PR DESCRIPTION
In some cases it is useful to know if the auth token is valid or not. 
All other immutable endpoints provide full information even without an auth token. 
Only fetching specific book of specific user does not work unauthorized, but this endpoint may be different depending if the book exist or not.
Added simple /me entrypoint that prints logged-in user info. 