### PR TITLE
feat: support external random seed

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,4 +14,5 @@ alive = int(os.getenv('tokentimetolive', 60))
 
 # start the app with port 5000 and debug on!
 if __name__ == '__main__':
-    vuln_app.run(host='0.0.0.0', port=5000, debug=True)
+    port = int(os.getenv('PORT', 5000))
+    vuln_app.run(host='0.0.0.0', port=port, debug=True)

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -1,12 +1,17 @@
 import datetime
 import jwt
+import os
 from sqlalchemy.orm import relationship
 from config import db, vuln_app
 from app import vuln, alive
 from models.books_model import Book
-from random import randrange
+from random import randrange, seed
 from sqlalchemy.sql import text
 
+rand_seed = os.getenv('RAND_SEED')
+if rand_seed is not None:
+    # Initialize the random seed if RAND_SEED is provided
+    seed(int(rand_seed))
 
 class User(db.Model):
     __tablename__ = 'users'


### PR DESCRIPTION
In some test cases would be nice to have a predicteble state of a database. 
Also make the port configurable, because 5000 sometimes is occupied on macOS (because of Airplay maybe)