### PR TITLE
removing outdated specifier

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
  vampi-secure:
   build: ./
@@ -7,6 +6,7 @@ services:
    - 5001:5000
   environment:
    - vulnerable=0
+   - tokentimetolive=3600
 
  vampi-vulnerable:
   build: ./
@@ -15,3 +15,4 @@ services:
    - 5002:5000
   environment:
    - vulnerable=1
+   - tokentimetolive=3600


### PR DESCRIPTION
there's a new warning that Docker throws up if you've an outdated "version" specifier. This PR removes that and also sets the TTL to 1 hour, which seems like a reasonable default and also provides implied documentation of the feature.

Hope you agree w/ the changes. Comments, updates, welcome as always!